### PR TITLE
:bug: Remove re-generation of nonce when frame validation

### DIFF
--- a/wsac-service/WsACService/Logging/ConsoleLogger.cs
+++ b/wsac-service/WsACService/Logging/ConsoleLogger.cs
@@ -2,6 +2,8 @@ namespace WsACService.Logging;
 
 public class ConsoleLogger(string name) : ILogger
 {
+    private static readonly Lock Lock = new();
+    
     private Dictionary<LogLevel, ConsoleColor> ColorMap { get; } = new()
     {
         [LogLevel.Trace]       = ConsoleColor.Gray,
@@ -22,13 +24,15 @@ public class ConsoleLogger(string name) : ILogger
         if (!IsEnabled(logLevel))
             return;
 
-        var old = Console.ForegroundColor;
-        Console.ForegroundColor = ColorMap[logLevel];
+        lock (Lock)
+        {
+            var old = Console.ForegroundColor;
+            Console.ForegroundColor = ColorMap[logLevel];
 
-        Console.Write($"[{eventId.Id,2}: {logLevel,-12}]    {name} - {formatter(state, exception)}");
+            Console.Write($"[{eventId.Id,2}: {logLevel,-12}]    {name} - {formatter(state, exception)}");
 
-        Console.ForegroundColor = old;
-        Console.WriteLine();
+            Console.ForegroundColor = old;
+        }
     }
 
     public bool IsEnabled(LogLevel _) => true;

--- a/wsac-service/WsACService/Net/FrameSession.cs
+++ b/wsac-service/WsACService/Net/FrameSession.cs
@@ -8,9 +8,9 @@ namespace WsACService.Net;
 
 public class FrameSession(ILogger logger, SessionState state, IWriter writer, IReader reader)
 {
-    public  SessionState State       { get; } = state;
-    
-    private FrameWriter  FrameWriter { get; } = new(writer);
+    public SessionState State { get; } = state;
+
+    private FrameWriter FrameWriter { get; } = new(writer);
 
     public async Task RunAsync(CancellationToken ct)
     {
@@ -85,7 +85,7 @@ public class FrameSession(ILogger logger, SessionState state, IWriter writer, IR
                 logger.LogWarning("broken preamble");
                 continue;
             }
-            
+
             logger.LogDebug("preamble received");
 
             if (!ReadHeader(out var header, ct))
@@ -95,7 +95,7 @@ public class FrameSession(ILogger logger, SessionState state, IWriter writer, IR
                 RequestCheckpoint();
                 continue;
             }
-            
+
             logger.LogDebug("header received (sig: {sig}, size: {siz})", header.Signature, header.DataSize);
 
             var bodyReader = reader.CreateChild(header.DataSize);


### PR DESCRIPTION
- Use lock to align log lines
- do NOT re-generate nonce when validation